### PR TITLE
Allow multiple words in one wordcloud phrase. separate via `,` or `;`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,6 +51,9 @@
              "my.datomic.com" {:url "https://my.datomic.com/repo"}}
 
  :aliases {:test {:extra-paths ["src/test"]
+                  ;; There is currently a kaocha bug, which prevents idiomatic fixtures, where the teardown is the last
+                  ;; action. When this is fixed, please revert the fixture in schnaq.test.toolbelt/init-test-delete-db-fixture
+                  ;; to end with (datomic/delete-database …)
                   :extra-deps {lambdaisland/kaocha {:mvn/version "1.75.1190"}
                                lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
                                day8.re-frame/test {:mvn/version "0.1.5"}}

--- a/deps.edn
+++ b/deps.edn
@@ -5,15 +5,15 @@
         clj-fuzzy/clj-fuzzy {:mvn/version "0.4.1"}
         clj-http/clj-http {:mvn/version "3.12.3"}
         cljs-ajax/cljs-ajax {:mvn/version "0.8.4"}
-        com.cognitect.aws/api {:mvn/version "0.8.630"}
-        com.cognitect.aws/endpoints {:mvn/version "1.1.12.358"}
+        com.cognitect.aws/api {:mvn/version "0.8.641"}
+        com.cognitect.aws/endpoints {:mvn/version "1.1.12.381"}
         com.cognitect.aws/s3 {:mvn/version "825.2.1250.0"}
         com.datomic/datomic-pro {:mvn/version "1.0.6397"}
         com.draines/postal {:mvn/version "2.0.5"}
         com.fulcrologic/guardrails {:mvn/version "1.1.11"}
         com.google.guava/guava {:mvn/version "31.1-jre"
                                 :doc "shadow-cljs needs this"}
-        com.stripe/stripe-java {:mvn/version "22.3.0"}
+        com.stripe/stripe-java {:mvn/version "22.6.0"}
         com.taoensso/sente {:mvn/version "1.17.0"}
         com.taoensso/tempura {:mvn/version "1.3.0"}
         com.taoensso/timbre {:mvn/version "6.0.4"}
@@ -23,7 +23,7 @@
         expound/expound {:mvn/version "0.9.0"}
         schnaq/hodgepodge {:git/url "https://github.com/schnaq/hodgepodge.git"
                            :sha "de1b57165647e186e4a18873eb2a2e93fff36a4e"}
-        funcool/promesa {:mvn/version "10.0.571"}
+        funcool/promesa {:mvn/version "10.0.594"}
         http-kit/http-kit {:mvn/version "2.6.0"}
         image-resizer/image-resizer {:mvn/version "0.1.10"}
         jarohen/chime {:mvn/version "0.3.3"}
@@ -31,7 +31,7 @@
         metosin/reitit {:mvn/version "0.5.18"}
         metosin/ring-http-response {:mvn/version "0.9.3"}
         metosin/spec-tools {:mvn/version "0.10.5"}
-        mount/mount {:mvn/version "0.1.16"}
+        mount/mount {:mvn/version "0.1.17"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/clojurescript {:mvn/version "1.11.60"}
         org.clojure/core.async {:mvn/version "1.6.673"}
@@ -43,7 +43,7 @@
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         ring/ring {:mvn/version "1.9.6"}
         ring/ring-mock {:mvn/version "0.4.0"}
-        thheller/shadow-cljs {:mvn/version "2.20.14"}
+        thheller/shadow-cljs {:mvn/version "2.20.20"}
         yogthos/config {:mvn/version "1.2.0"}}
 
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
@@ -51,7 +51,7 @@
              "my.datomic.com" {:url "https://my.datomic.com/repo"}}
 
  :aliases {:test {:extra-paths ["src/test"]
-                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.75.1190"}
                                lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
                                day8.re-frame/test {:mvn/version "0.1.5"}}
                   :main-opts ["-m" "kaocha.runner"]}

--- a/schnaq.iml
+++ b/schnaq.iml
@@ -10,6 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/resources" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/dev" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -20,12 +21,12 @@
     <orderEntry type="library" name="Deps: buddy/buddy-core:1.10.413" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/data.json:2.4.0" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/clojure:1.11.1" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/deep-diff2:2.4.138" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/deep-diff2:2.7.169" level="project" />
     <orderEntry type="library" name="Deps: thheller/shadow-cljsjs:0.0.22" level="project" />
     <orderEntry type="library" name="Deps: joda-time:2.8.1" level="project" />
     <orderEntry type="library" name="Deps: day8.re-frame/test:0.1.5" level="project" />
     <orderEntry type="library" name="Deps: commons-codec:1.15" level="project" />
-    <orderEntry type="library" name="Deps: com.cognitect.aws/api:0.8.612" level="project" />
+    <orderEntry type="library" name="Deps: com.cognitect.aws/api:0.8.641" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/tools.analyzer:1.1.0" level="project" />
     <orderEntry type="library" name="Deps: amperity/envoy:0.3.3" level="project" />
     <orderEntry type="library" name="Deps: com.bhauman/cljs-test-display:0.1.1" level="project" />
@@ -33,7 +34,7 @@
     <orderEntry type="library" name="Deps: org.apache.tomcat/tomcat-juli:7.0.109" level="project" />
     <orderEntry type="library" name="Deps: org.apache.commons/commons-compress:1.21" level="project" />
     <orderEntry type="library" name="Deps: ring/ring-devel:1.9.6" level="project" />
-    <orderEntry type="library" name="Deps: com.cognitect.aws/endpoints:1.1.12.338" level="project" />
+    <orderEntry type="library" name="Deps: com.cognitect.aws/endpoints:1.1.12.381" level="project" />
     <orderEntry type="library" name="Deps: com.google.errorprone/error_prone_annotations:2.15.0" level="project" />
     <orderEntry type="library" name="Deps: org.apache.commons/commons-lang3:3.8.1" level="project" />
     <orderEntry type="library" name="Deps: com.draines/postal:2.0.5" level="project" />
@@ -47,7 +48,7 @@
     <orderEntry type="library" name="Deps: metosin/muuntaja:0.6.8" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-common:4.1.73.Final" level="project" />
     <orderEntry type="library" name="Deps: com.fasterxml.jackson.module/jackson-module-jaxb-annotations:2.13.2" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/kaocha:1.71.1119" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/kaocha:1.75.1190" level="project" />
     <orderEntry type="library" name="Deps: jakarta.validation/jakarta.validation-api:2.0.2" level="project" />
     <orderEntry type="library" name="Deps: io.undertow/undertow-core:2.2.4.Final" level="project" />
     <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-credentials:1.3.0" level="project" />
@@ -56,7 +57,7 @@
     <orderEntry type="library" name="Deps: expound:0.9.0" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/spec.alpha:0.3.218" level="project" />
     <orderEntry type="library" name="Deps: cli-matic:0.4.3" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.0.206" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.0.214" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-transport-native-kqueue$osx-x86_64:4.1.73.Final" level="project" />
     <orderEntry type="library" name="Deps: org.keycloak/keycloak-core:18.0.0" level="project" />
     <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-iam-v1:1.2.0" level="project" />
@@ -65,14 +66,14 @@
     <orderEntry type="library" name="Deps: commons-fileupload:1.4" level="project" />
     <orderEntry type="library" name="Deps: tick:0.4.14-alpha" level="project" />
     <orderEntry type="library" name="Deps: org.codehaus.mojo/animal-sniffer-annotations:1.20" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/clj-diff:1.3.67" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/clj-diff:1.4.78" level="project" />
     <orderEntry type="library" name="Deps: javax.activation/activation:1.1" level="project" />
     <orderEntry type="library" name="Deps: io.perfmark/perfmark-api:0.23.0" level="project" />
     <orderEntry type="library" name="Deps: clojure-future-spec:1.9.0" level="project" />
     <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-http:9.4.48.v20220622" level="project" />
     <orderEntry type="library" name="Deps: day8.re-frame/http-fx:0.2.4" level="project" />
     <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-util:9.4.48.v20220622" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/encore:3.31.0" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/encore:3.43.0" level="project" />
     <orderEntry type="library" name="Deps: com.lucasbradstreet/cljs-uuid-utils:1.0.2" level="project" />
     <orderEntry type="library" name="Deps: org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec:2.0.1.Final" level="project" />
     <orderEntry type="library" name="Deps: org.slf4j/jcl-over-slf4j:1.7.32" level="project" />
@@ -115,7 +116,7 @@
     <orderEntry type="library" name="Deps: com.github.fge/msg-simple:1.1" level="project" />
     <orderEntry type="library" name="Deps: com.h2database/h2:1.3.171" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-codec-socks:4.1.73.Final" level="project" />
-    <orderEntry type="library" name="Deps: thheller/shadow-cljs:2.20.12" level="project" />
+    <orderEntry type="library" name="Deps: thheller/shadow-cljs:2.20.20" level="project" />
     <orderEntry type="library" name="Deps: org.apache.johnzon/johnzon-core:0.9.5" level="project" />
     <orderEntry type="library" name="Deps: org.apache.activemq/artemis-commons:2.19.1" level="project" />
     <orderEntry type="library" name="Deps: org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec:2.0.1.Final" level="project" />
@@ -143,7 +144,7 @@
     <orderEntry type="library" name="Deps: fipp:0.6.26" level="project" />
     <orderEntry type="library" name="Deps: org.apache.tomcat/tomcat-jdbc:7.0.109" level="project" />
     <orderEntry type="library" name="Deps: org.jboss.logging/jboss-logging:3.4.2.Final" level="project" />
-    <orderEntry type="library" name="Deps: com.nextjournal/beholder:1.0.0" level="project" />
+    <orderEntry type="library" name="Deps: com.nextjournal/beholder:1.0.1" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-swagger:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-core:2.13.2" level="project" />
     <orderEntry type="library" name="Deps: org.yaml/snakeyaml:1.31" level="project" />
@@ -161,7 +162,7 @@
     <orderEntry type="library" name="Deps: thheller/shadow-util:0.7.0" level="project" />
     <orderEntry type="library" name="Deps: com.datomic/memcache-asg-java-client:1.1.0.33" level="project" />
     <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient-cache:4.5.13" level="project" />
-    <orderEntry type="library" name="Deps: mvxcvi/arrangement:2.0.0" level="project" />
+    <orderEntry type="library" name="Deps: mvxcvi/arrangement:2.1.0" level="project" />
     <orderEntry type="library" name="Deps: instaparse:1.4.8" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-tcnative-classes:2.0.46.Final" level="project" />
     <orderEntry type="library" name="Deps: clj-commons/fs:1.6.309" level="project" />
@@ -169,14 +170,14 @@
     <orderEntry type="library" name="Deps: com.google.http-client/google-http-client:1.41.0" level="project" />
     <orderEntry type="library" name="Deps: schnaq/hodgepodge:de1b57" level="project" />
     <orderEntry type="library" name="Deps: com.cognitect/transit-js:0.8.874" level="project" />
-    <orderEntry type="library" name="Deps: io.methvin/directory-watcher:0.17.0" level="project" />
+    <orderEntry type="library" name="Deps: io.methvin/directory-watcher:0.17.1" level="project" />
     <orderEntry type="library" name="Deps: org.imgscalr/imgscalr-lib:4.2" level="project" />
     <orderEntry type="library" name="Deps: clj-tuple:0.2.2" level="project" />
     <orderEntry type="library" name="Deps: org.apache.james/apache-mime4j:0.6" level="project" />
     <orderEntry type="library" name="Deps: com.sun.istack/istack-commons-runtime:3.0.10" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-core:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: com.sun.mail/javax.mail:1.6.2" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/truss:1.6.0" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/truss:1.7.2" level="project" />
     <orderEntry type="library" name="Deps: org.keycloak/keycloak-adapter-core:18.0.0" level="project" />
     <orderEntry type="library" name="Deps: com.github.fge/json-patch:1.9" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/google-closure-library-third-party:0.0-20211011-0726fdeb" level="project" />
@@ -200,7 +201,7 @@
     <orderEntry type="library" name="Deps: commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Deps: com.google.guava/failureaccess:1.0.1" level="project" />
     <orderEntry type="library" name="Deps: environ:1.2.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.guava/guava:31.0.1-jre" level="project" />
+    <orderEntry type="library" name="Deps: com.google.guava/guava:31.1-jre" level="project" />
     <orderEntry type="library" name="Deps: io.grpc/grpc-protobuf:1.43.2" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-transport-native-epoll$linux-x86_64:4.1.73.Final" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/data.xml:0.2.0-alpha8" level="project" />
@@ -221,7 +222,7 @@
     <orderEntry type="library" name="Deps: org.jboss.threads/jboss-threads:3.1.0.Final" level="project" />
     <orderEntry type="library" name="Deps: com.google.j2objc/j2objc-annotations:1.3" level="project" />
     <orderEntry type="library" name="Deps: cljc.java-time:0.1.1" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/timbre:6.0.2" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/timbre:6.0.4" level="project" />
     <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-secretmanager:2.0.7" level="project" />
     <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-common-protos:2.7.1" level="project" />
     <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1:2.0.7" level="project" />
@@ -251,7 +252,7 @@
     <orderEntry type="library" name="Deps: com.bhauman/spell-spec:0.1.2" level="project" />
     <orderEntry type="library" name="Deps: org.apache.ant/ant:1.10.11" level="project" />
     <orderEntry type="library" name="Deps: crypto-equality:1.0.1" level="project" />
-    <orderEntry type="library" name="Deps: funcool/promesa:9.2.541" level="project" />
+    <orderEntry type="library" name="Deps: funcool/promesa:10.0.594" level="project" />
     <orderEntry type="library" name="Deps: org.checkerframework/checker-qual:3.20.0" level="project" />
     <orderEntry type="library" name="Deps: io.grpc/grpc-core:1.43.2" level="project" />
     <orderEntry type="library" name="Deps: org.wildfly.client/wildfly-client-config:1.0.1.Final" level="project" />
@@ -259,6 +260,7 @@
     <orderEntry type="library" name="Deps: net.java.dev.jna/jna:5.12.1" level="project" />
     <orderEntry type="library" name="Deps: cheshire:5.10.1" level="project" />
     <orderEntry type="library" name="Deps: tigris:0.1.2" level="project" />
+    <orderEntry type="library" name="Deps: yogthos/config:1.2.0" level="project" />
     <orderEntry type="library" name="Deps: org.java-websocket/Java-WebSocket:1.5.3" level="project" />
     <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-client:9.4.48.v20220622" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-sieppari:0.5.18" level="project" />
@@ -280,7 +282,7 @@
     <orderEntry type="library" name="Deps: potemkin:0.4.5" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-http:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: nrepl:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: mount:0.1.16" level="project" />
+    <orderEntry type="library" name="Deps: mount:0.1.17" level="project" />
     <orderEntry type="library" name="Deps: buddy/buddy-auth:3.0.323" level="project" />
     <orderEntry type="library" name="Deps: io.netty/netty-resolver:4.1.73.Final" level="project" />
     <orderEntry type="library" name="Deps: binaryage/oops:0.7.2" level="project" />
@@ -291,7 +293,7 @@
     <orderEntry type="library" name="Deps: com.google.re2j/re2j:1.5" level="project" />
     <orderEntry type="library" name="Deps: org.jboss.xnio/xnio-api:3.8.0.Final" level="project" />
     <orderEntry type="library" name="Deps: buddy/buddy-sign:3.4.333" level="project" />
-    <orderEntry type="library" name="Deps: com.google.javascript/closure-compiler-unshaded:v20221102" level="project" />
+    <orderEntry type="library" name="Deps: com.google.javascript/closure-compiler-unshaded:v20230103" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/test.check:1.1.1" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-frontend:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider:2.13.2" level="project" />
@@ -300,7 +302,7 @@
     <orderEntry type="library" name="Deps: org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec:2.0.1.Final" level="project" />
     <orderEntry type="library" name="Deps: org.jboss.resteasy/resteasy-jaxrs:3.15.3.Final" level="project" />
     <orderEntry type="library" name="Deps: metosin/jsonista:0.3.6" level="project" />
-    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java:3.19.3" level="project" />
+    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java:3.19.6" level="project" />
     <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-oauth2-http:1.3.0" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-swagger-ui:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit:0.5.18" level="project" />
@@ -325,7 +327,7 @@
     <orderEntry type="library" name="Deps: borkdude/sci.impl.reflector:0.0.1" level="project" />
     <orderEntry type="library" name="Deps: com.sun.mail/jakarta.mail:1.6.5" level="project" />
     <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-server:9.4.48.v20220622" level="project" />
-    <orderEntry type="library" name="Deps: com.stripe/stripe-java:22.1.0" level="project" />
+    <orderEntry type="library" name="Deps: com.stripe/stripe-java:22.6.0" level="project" />
     <orderEntry type="library" name="Deps: io.opencensus/opencensus-api:0.28.0" level="project" />
     <orderEntry type="library" name="Deps: io.grpc/grpc-auth:1.43.2" level="project" />
     <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpmime:4.5.13" level="project" />
@@ -350,7 +352,7 @@
     <orderEntry type="library" name="Deps: juji/editscript:0.5.7" level="project" />
     <orderEntry type="library" name="Deps: javax.xml.bind/jaxb-api:2.3.0" level="project" />
     <orderEntry type="library" name="Deps: metosin/sieppari:0.0.0-alpha13" level="project" />
-    <orderEntry type="library" name="Deps: com.google.code.gson/gson:2.9.1" level="project" />
+    <orderEntry type="library" name="Deps: com.google.code.gson/gson:2.10.1" level="project" />
     <orderEntry type="library" name="Deps: metosin/reitit-interceptors:0.5.18" level="project" />
     <orderEntry type="library" name="Deps: http-kit:2.6.0" level="project" />
   </component>

--- a/src/main/schnaq/interface/translations/english.cljs
+++ b/src/main/schnaq/interface/translations/english.cljs
@@ -199,7 +199,7 @@
    :schnaq.wordcloud.local.create/label "Question or Prompt"
    :schnaq.wordcloud.local.create/button "Start Word Cloud"
    :schnaq.wordcloud.local.add-words/label "Enter your words here"
-   :schnaq.wordcloud.local.add-words/hint "You can add multiple words, they will be split at the whitespace."
+   :schnaq.wordcloud.local.add-words/hint "You can add multiple phrases, split at a comma."
    :schnaq.wordcloud.local/delete-button "Delete"
    :schnaq.wordcloud.local/delete-confirmation "Do you really want to delete the wordcloud permanently?"
    :schnaq.wordcloud/download "Download Word Cloud"

--- a/src/main/schnaq/interface/translations/german.cljs
+++ b/src/main/schnaq/interface/translations/german.cljs
@@ -202,7 +202,7 @@
    :schnaq.wordcloud.local.create/label "Frage oder Überschrift"
    :schnaq.wordcloud.local.create/button "Lege Wortwolke an"
    :schnaq.wordcloud.local.add-words/label "Wörter hier einfügen"
-   :schnaq.wordcloud.local.add-words/hint "Du kannst mehrere Wörter, per Leerzeichen getrennt, eintippen."
+   :schnaq.wordcloud.local.add-words/hint "Du kannst mehrere Begriffe, per Komma getrennt, eintippen."
    :schnaq.wordcloud.local/delete-button "Löschen"
    :schnaq.wordcloud.local/delete-confirmation "Möchtest du die Wortwolke wirklich permanent löschen?"
    :schnaq.wordcloud/download "Wortwolke herunterladen"

--- a/src/main/schnaq/interface/views/schnaq/wordcloud_card.cljs
+++ b/src/main/schnaq/interface/views/schnaq/wordcloud_card.cljs
@@ -217,9 +217,11 @@
 (rf/reg-event-fx
  :schnaq.wordcloud.local/send-words
  (fn [{:keys [db]} [_ wordcloud-id unprocessed-words]]
-   (let [words (->> (str/split (wordcloud/remove-md-links unprocessed-words) #"\s")
+   (let [words (->> (str/split (wordcloud/remove-md-links unprocessed-words) #"[,|;]")
                     (map wordcloud/extract-link-text-from-md)
-                    (map #(str/replace % #"[^A-z0-9äöüÄÖÜß]" "")) ;; remove all non-word characters
+                    (map #(str/replace % #"[^A-z0-9äöüÄÖÜß\ ]" "")) ;; remove all non-word characters
+                    ;; remove leading and trailing whitespace
+                    (map str/trim)
                     (map str/lower-case)
                     distinct
                     ;; Experimentally deactivated stopwords,

--- a/src/test/schnaq/test/toolbelt.clj
+++ b/src/test/schnaq/test/toolbelt.clj
@@ -30,14 +30,18 @@
    (database/init-and-seed! datomic-test-uri test-data)
    (f)))
 
+;; A bug in kaocha seems to try to interpret the result of the fixture and not of the test. Which means, until it is
+;; fixed, we need to return the result of f and not end on any other function call.
 (defn init-test-delete-db-fixture
   "Fixture to initialize, test, and afterwards delete the database."
   ([f]
-   (init-db-test-fixture f)
-   (datomic/delete-database datomic-test-uri))
+   (let [result (init-db-test-fixture f)]
+     (datomic/delete-database datomic-test-uri)
+     result))
   ([f test-data]
-   (init-db-test-fixture f test-data)
-   (datomic/delete-database datomic-test-uri)))
+   (let [result (init-db-test-fixture f test-data)]
+     (datomic/delete-database datomic-test-uri)
+     result)))
 
 ;; -----------------------------------------------------------------------------
 ;; Generative Test Helpers


### PR DESCRIPTION
closes #66 

Allows the user to input multiple words per phrase in the wordcloud. The words are separated via comma or semicolon. Leading and trailing whitespaces are removed.