### PR TITLE
SMTP audit: email config diagnostics and send error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This document provides guidance for AI agents (like Claude Code, GitHub Copilot,
 ## Technology Stack
 
 ### Backend (Clojure)
-- **Language**: Clojure 1.11.3
+- **Language**: Clojure 1.12.4
 - **Web Framework**: Reitit 0.7.1 (routing + middleware)
 - **HTTP Server**: http-kit 2.8.0
 - **Database**: Datomic Pro (immutable, time-travel DB)
@@ -439,7 +439,7 @@ Key environment variables (defined in [config.clj](src/main/schnaq/config.clj)):
 - `DATOMIC_URI` - Database connection string
 - `KEYCLOAK_*` - Keycloak authentication config
 - `AWS_*` - AWS S3 credentials
-- `SMTP_*` - Email server configuration
+- `EMAIL_SENDER_ADDRESS`, `EMAIL_HOST`, `EMAIL_USERNAME`, `EMAIL_PASSWORD` - Email server configuration (optional `EMAIL_PORT`, default 465)
 - `API_URL` - Backend API URL
 - `BUILD_HASH` - Version identifier
 

--- a/src/main/schnaq/api.clj
+++ b/src/main/schnaq/api.clj
@@ -1,5 +1,6 @@
 (ns schnaq.api
-  (:require [expound.alpha :as expound]
+  (:require [clojure.string :as str]
+            [expound.alpha :as expound]
             [mount.core :as mount :refer [defstate]]
             [muuntaja.core :as m]
             [org.httpkit.server :as server]
@@ -39,6 +40,7 @@
             [schnaq.config.keycloak :as keycloak-config]
             [schnaq.config.shared :as shared-config]
             [schnaq.core] ;; Keep this import to activate database etc.
+            [schnaq.mail.emails :as emails]
             [schnaq.toolbelt :as toolbelt]
             [schnaq.websockets.handler :refer [websocket-routes]]
             [schnaq.websockets.messages]
@@ -57,7 +59,10 @@
   (log/info (format "Database Name: %s" config/db-name))
   (log/info (format "Database URI (truncated): %s..." (subs config/datomic-uri 0 30)))
   (log/info (format "Frontend URL: %s, host: %s" config/frontend-url config/frontend-host))
-  (log/info (if (:sender-password config/email) "E-Mail configured" "E-Mail not configured"))
+  (log/info (if (emails/mail-configured?)
+              "E-Mail configured"
+              (str "E-Mail not configured. Missing: "
+                   (str/join ", " (emails/missing-email-config-keys)))))
   (log/info (format "[Keycloak] Server: %s, Realm: %s" keycloak-config/server keycloak-config/realm)))
 
 (def ^:private description

--- a/src/main/schnaq/config.clj
+++ b/src/main/schnaq/config.clj
@@ -54,6 +54,7 @@
 (def email
   {:sender-address (:email-sender-address env)
    :sender-host (:email-host env)
+   :sender-port (Integer/parseInt (or (:email-port env) "465"))
    :sender-username (:email-username env)
    :sender-password (:email-password env)})
 

--- a/src/main/schnaq/mail/emails.clj
+++ b/src/main/schnaq/mail/emails.clj
@@ -1,6 +1,7 @@
 (ns schnaq.mail.emails
   "Handle sending emails to users."
   (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]
             [com.fulcrologic.guardrails.core :refer [>defn >defn- ?]]
             [hiccup.util :as hiccup-util]
             [postal.core :refer [send-message]]
@@ -10,13 +11,38 @@
             [schnaq.mail.template :as template]
             [taoensso.timbre :as log]))
 
+(def ^:private email-config->env-var
+  {:sender-address "EMAIL_SENDER_ADDRESS"
+   :sender-host "EMAIL_HOST"
+   :sender-username "EMAIL_USERNAME"
+   :sender-password "EMAIL_PASSWORD"})
+
+(defn missing-email-config-keys
+  "Return env var names for unset email configuration values."
+  []
+  (->> config/email
+       (filter (fn [[_ v]] (empty? v)))
+       (map (fn [[k _]] (get email-config->env-var k (name k))))
+       vec))
+
+(defn mail-configured?
+  "True when all required email configuration values are set."
+  []
+  (empty? (missing-email-config-keys)))
+
 (def ^:private conn {:host (:sender-host config/email)
+                     :port (:sender-port config/email)
                      :ssl true
                      :user (:sender-username config/email)
                      :pass (:sender-password config/email)})
 
-(def ^:private mail-configured?
-  (every? not-empty (vals config/email)))
+(def ^:private missing-config-logged? (atom false))
+
+(defn- log-missing-email-config-once!
+  []
+  (when (compare-and-set! missing-config-logged? false true)
+    (log/warn "E-Mail not configured. Missing environment variables:"
+              (str/join ", " (missing-email-config-keys)))))
 
 (>defn- valid-mail
   "Check valid mail"
@@ -28,25 +54,36 @@
 
 (def ^:private failed-sendings (atom '()))
 
+(defn- postal-send-success?
+  [result]
+  (zero? (:code result 99)))
+
 (>defn- send-mail-with-custom-body
   "Sends a single mail to a recipient with a passed body."
   [title recipient body]
   [string? string? coll? :ret (? coll?)]
-  (if mail-configured?
+  (if (mail-configured?)
     (if (valid-mail recipient)
       (try
-        (send-message conn {:from (:sender-address config/email)
-                            :to recipient
-                            :subject title
-                            :body body})
-        (log/info "Sent mail to" recipient)
-        (Thread/sleep 100)
+        (let [result (send-message conn {:from (:sender-address config/email)
+                                         :to recipient
+                                         :subject title
+                                         :body body})]
+          (if (postal-send-success? result)
+            (do
+              (log/info "Sent mail to" recipient)
+              (Thread/sleep 100))
+            (do
+              (log/error "Failed to send mail to" recipient "postal returned" result)
+              (swap! failed-sendings conj recipient))))
         (catch Exception exception
           (log/error "Failed to send mail to" recipient)
           (log/error exception)
           (swap! failed-sendings conj recipient)))
       (swap! failed-sendings conj recipient))
-    (log/info (format "Should send an email to %s now, but email is not configured." recipient))))
+    (do
+      (log-missing-email-config-once!)
+      (log/info (format "Should send an email to %s now, but email is not configured." recipient)))))
 
 (>defn send-mail
   "Sends a single mail to the recipient. Title and content are used as passed."

--- a/src/main/schnaq/mail/template.clj
+++ b/src/main/schnaq/mail/template.clj
@@ -1,6 +1,17 @@
 (ns schnaq.mail.template
   (:require [clojure.string :as cstring]
-            [schnaq.config :as config]))
+            [schnaq.config :as config]
+            [taoensso.timbre :as log]))
+
+(defn- load-template
+  "Load an HTML mail template from `url`, logging and rethrowing on failure."
+  [url]
+  (try
+    (slurp url)
+    (catch Exception e
+      (log/error "Failed to load mail template from" url)
+      (log/error e)
+      (throw e))))
 
 (defn mail
   "Basic html mail template with a schnaq logo and passed heading.
@@ -25,7 +36,7 @@
              (str "\n\n" additional-plain-content))
            "\n\n\nSchöne Grüße\n\ndein schnaq Team")}
      {:type "text/html; charset=utf-8" :content
-      (reduce replace-fn (slurp config/mail-template) format-map)}]))
+      (reduce replace-fn (load-template config/mail-template) format-map)}]))
 
 (defn mail-content-left-button-right
   "Additional html content to display content on the left side and a button on the right side"
@@ -35,4 +46,4 @@
                     "$$$LEFT-CONTENT-BOTTOM$$$" content-subtitle
                     "$$$BUTTON-TEXT$$$" button-text
                     "$$$BUTTON-LINK$$$" button-link}]
-    (reduce replace-fn (slurp config/mail-content-button-right-template) format-map)))
+    (reduce replace-fn (load-template config/mail-content-button-right-template) format-map)))


### PR DESCRIPTION
## Summary
- Restore configurable `EMAIL_PORT` (default 465) in `config.clj` and pass it to Postal.
- Add `mail-configured?` / `missing-email-config-keys` helpers; log missing `EMAIL_*` env vars once when send is attempted without config.
- Treat non-zero Postal return codes as send failures (in addition to exceptions).
- Wrap S3 mail template `slurp` in try/catch with error logging.
- Log which `EMAIL_*` variables are missing at API startup when mail is not configured.
- Fix `AGENTS.md` to document `EMAIL_*` (not `SMTP_*`) and correct Clojure version.

**Ops note:** Production deployments should verify `EMAIL_SENDER_ADDRESS`, `EMAIL_HOST`, `EMAIL_USERNAME`, and `EMAIL_PASSWORD` (and optionally `EMAIL_PORT`) — not legacy `SMTP_*` names.

## Test plan
- [ ] `clojure -M:test`
- [ ] `clj-kondo --lint src/main/schnaq/mail src/main/schnaq/config.clj src/main/schnaq/api.clj`
- [ ] Start backend without email env vars; confirm startup log lists missing `EMAIL_*` keys
- [ ] Start backend with full email config; confirm "E-Mail configured" at startup
- [ ] Trigger a mail send (or unit path) and confirm Postal non-zero codes are logged as failures


Made with [Cursor](https://cursor.com)