### PR TITLE
Fix CI: mail-configured? crash on EMAIL_PORT integer

### DIFF
--- a/src/main/schnaq/mail/emails.clj
+++ b/src/main/schnaq/mail/emails.clj
@@ -17,12 +17,17 @@
    :sender-username "EMAIL_USERNAME"
    :sender-password "EMAIL_PASSWORD"})
 
+(defn- email-value-missing?
+  [v]
+  (or (nil? v) (and (string? v) (empty? v))))
+
 (defn missing-email-config-keys
   "Return env var names for unset email configuration values."
   []
-  (->> config/email
-       (filter (fn [[_ v]] (empty? v)))
-       (map (fn [[k _]] (get email-config->env-var k (name k))))
+  (->> email-config->env-var
+       (keep (fn [[config-key env-var]]
+               (when (email-value-missing? (get config/email config-key))
+                 env-var)))
        vec))
 
 (defn mail-configured?


### PR DESCRIPTION
## Summary
- Fix `missing-email-config-keys` so it only checks required string email settings (not `:sender-port`).
- Prevents `IllegalArgumentException: Don't know how to create ISeq from: java.lang.Integer` when `empty?` runs on the default port `465`, which caused `/feedback/add` to return 500 and broke `schnaq.api.feedback-test` after #152.

## Root cause
PR #152 added `EMAIL_PORT` to `config/email` as an integer and introduced `mail-configured?` / `missing-email-config-keys` that iterated all entries with `(empty? v)`. Clojure's `empty?` does not accept integers.

## Test plan
- [x] `clojure -M:test --focus schnaq.api.feedback-test`
- [x] `clojure -M:test` (246 tests, 0 failures)
- [x] `clj-kondo --lint src/main/schnaq/mail/emails.clj`


Made with [Cursor](https://cursor.com)