### PR TITLE
Fix ESLint for Excalidraw vendor script (CI on develop)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,11 +15,17 @@ module.exports = [
   },
   js.configs.recommended,
   {
-    files: ['**/*.js'],
+    files: ['**/*.{js,mjs,cjs}'],
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: 'commonjs',
+      sourceType: 'module',
       globals: { ...globals.node, ...globals.browser },
+    },
+  },
+  {
+    files: ['**/*.cjs', 'eslint.config.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
     },
   },
 ];

--- a/scripts/bundle-excalidraw.mjs
+++ b/scripts/bundle-excalidraw.mjs
@@ -10,43 +10,43 @@
  * feature and it pulls a ~10MB dependency graph that breaks shadow-cljs
  * package-exports resolution (@upsetjs/venn.js).
  */
-import * as esbuild from "esbuild";
-import { mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import * as esbuild from 'esbuild';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const outfile = join(root, "target/vendor/excalidraw.cjs.js");
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outfile = join(root, 'target/vendor/excalidraw.cjs.js');
 
 mkdirSync(dirname(outfile), { recursive: true });
 
 const stubMermaid = {
-  name: "stub-mermaid",
+  name: 'stub-mermaid',
   setup(build) {
     build.onResolve(
       { filter: /^(mermaid|@excalidraw\/mermaid-to-excalidraw)(\/.*)?$/ },
-      (args) => ({ path: args.path, namespace: "mermaid-stub" }),
+      (args) => ({ path: args.path, namespace: 'mermaid-stub' }),
     );
-    build.onLoad({ filter: /.*/, namespace: "mermaid-stub" }, () => ({
-      contents: "module.exports = {};",
-      loader: "js",
+    build.onLoad({ filter: /.*/, namespace: 'mermaid-stub' }, () => ({
+      contents: 'module.exports = {};',
+      loader: 'js',
     }));
   },
 };
 
 await esbuild.build({
-  entryPoints: ["@excalidraw/excalidraw"],
+  entryPoints: ['@excalidraw/excalidraw'],
   bundle: true,
-  format: "cjs",
-  platform: "browser",
+  format: 'cjs',
+  platform: 'browser',
   outfile,
   // Keep React as peer deps so the app's single React copy is used.
-  external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
+  external: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
   plugins: [stubMermaid],
-  logLevel: "info",
+  logLevel: 'info',
   // Workers / import.meta.url get inlined or stubbed by esbuild for CJS.
   define: {
-    "import.meta.url": '""',
+    'import.meta.url': '""',
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI on `develop` after #154 failed ESLint because `scripts/bundle-excalidraw.mjs` uses `console` and only `**/*.js` had Node globals configured.

## Changes

- Extend ESLint flat config to `**/*.{js,mjs,cjs}` with Node/browser globals
- Keep CommonJS for `eslint.config.js` / `*.cjs`
- Prettier-format the vendor script

## Note on clj-kondo

The separate „Lint code“ job also fails with **exit 2 / 0 errors, 11 warnings**. Those warnings are pre-existing (not from #154) — clj-kondo treats warnings as non-zero by default. Out of scope here unless you want `--fail-level error` in the workflow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76b5e783-0ff6-4bc0-ad0b-4fcdd16ef780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76b5e783-0ff6-4bc0-ad0b-4fcdd16ef780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

