### PR TITLE
Fix clj-kondo warnings blocking CI lint job

### DIFF
--- a/src/main/schnaq/database/feedback_form.clj
+++ b/src/main/schnaq/database/feedback_form.clj
@@ -44,8 +44,11 @@
   [share-hash form-items visible?]
   [:discussion/share-hash :feedback/items boolean? => (? :db/id)]
   (when-not (empty? form-items)
-    (when-let [feedback-id (:db/id (:discussion/feedback (db/fast-pull [:discussion/share-hash share-hash] patterns/discussion)))]
-      (let [current-items (feedback-items share-hash)
+    ;; Pull feedback directly — do not use `feedback-items`, which only
+    ;; returns items when the form is already visible.
+    (when-let [feedback (:discussion/feedback (db/fast-pull [:discussion/share-hash share-hash] patterns/discussion))]
+      (let [feedback-id (:db/id feedback)
+            current-items (:feedback/items feedback)
             new-item-ids (set (remove nil? (map :db/id form-items)))
             items-to-remove (remove #(new-item-ids (:db/id %)) current-items)]
         @(db/transact
@@ -57,8 +60,8 @@
                                                                     (str "item-" (:feedback.item/ordinal %))))
                      form-items)
                 ;; IMPORTANT: The % must be second in merge, since we want to preserve existing :db/ids
-                (map #(merge {:db/id (str "item-" (:feedback.item/ordinal %))} %) form-items)))))
-      feedback-id)))
+                (map #(merge {:db/id (str "item-" (:feedback.item/ordinal %))} %) form-items))))
+        feedback-id))))
 
 (>defn add-answers
   "Add new answers to a feedback."

--- a/src/main/schnaq/interface/components/common.cljs
+++ b/src/main/schnaq/interface/components/common.cljs
@@ -69,8 +69,8 @@
                     (and enterprise-user? (not beta-tester?)) [enterprise-badge]
                     beta-tester? [tester-badge]
                     :else [pro-badge])]
-    (when indicator
-      [:span.px-1 indicator])))
+    ;; `cond` always returns a badge via `:else`
+    [:span.px-1 indicator]))
 
 ;; -----------------------------------------------------------------------------
 

--- a/src/main/schnaq/interface/views/discussion/card_elements.cljs
+++ b/src/main/schnaq/interface/views/discussion/card_elements.cljs
@@ -30,15 +30,15 @@
                      (labels :history.all-schnaqs/label))
         navigation-target (if has-history? back-history back-feed)
         tooltip (if has-history? :history.back/tooltip :history.all-schnaqs/tooltip)]
-    (when navigation-target
-      [:div.d-flex.flex-row.panel-white-sm
-       [tooltip/text
-        (labels tooltip)
-        [:button.btn.btn-dark
-         {:on-click #(rf/dispatch navigation-target)}
-         [:div.d-flex
-          [icon :arrow-left "m-auto"]]]]
-       [:small.my-auto.ms-2 back-label]])))
+    ;; `navigation-target` is always a vector (history event or overview route)
+    [:div.d-flex.flex-row.panel-white-sm
+     [tooltip/text
+      (labels tooltip)
+      [:button.btn.btn-dark
+       {:on-click #(rf/dispatch navigation-target)}
+       [:div.d-flex
+        [icon :arrow-left "m-auto"]]]]
+     [:small.my-auto.ms-2 back-label]]))
 
 (defn- discussion-start-button
   "Discussion start button for history view"

--- a/src/main/schnaq/interface/views/schnaq/qa_box.cljs
+++ b/src/main/schnaq/interface/views/schnaq/qa_box.cljs
@@ -220,7 +220,8 @@
 (rf/reg-event-db
  :qa-boxes.load-from-backend/success
  (fn [db [_ response]]
-   (when-let [qa-boxes (shared-tools/normalize :db/id (:qa-boxes response))]
+   ;; `normalize` always returns a map (possibly empty)
+   (let [qa-boxes (shared-tools/normalize :db/id (:qa-boxes response))]
      (assoc-in db [:schnaq :qa-boxes] qa-boxes))))
 
 (rf/reg-event-fx

--- a/src/main/schnaq/interface/views/schnaq/visited.cljs
+++ b/src/main/schnaq/interface/views/schnaq/visited.cljs
@@ -118,10 +118,12 @@
            visited-hashes-with-faq (conj visited-hashes config/faq-share-hash)
            share-hashes (if shared-config/production? visited-hashes-with-faq visited-hashes)
            share-hashes (->> share-hashes (remove nil?) (remove #(= % "")))
-           schnaq-filter (keyword (get-in db [:current-route :parameters :query :filter]))]
-          (when-not (empty? share-hashes)
+           ;; Check raw query value before `keyword` — `(keyword nil)` is nil, but
+           ;; clj-kondo treats `keyword` as always truthy (:constant-condition).
+           schnaq-filter (get-in db [:current-route :parameters :query :filter])]
+          (when (seq share-hashes)
                     {:db (if schnaq-filter
-                             (assoc-in db [:schnaqs :filter] schnaq-filter)
+                             (assoc-in db [:schnaqs :filter] (keyword schnaq-filter))
                              (update db :schnaqs dissoc :filter))
                      :fx [(http/xhrio-request
                            db :post "/schnaqs/by-hashes"

--- a/src/test/schnaq/database/analytics_test.clj
+++ b/src/test/schnaq/database/analytics_test.clj
@@ -71,7 +71,7 @@
       (is (< (:min stats) (:median stats)))
       (is (> (:max stats) (:median stats)))
       (is (> (:max stats) (:average stats)))
-      (is float? (:average stats)))))
+      (is (float? (:average stats))))))
 
 (deftest statement-type-stats-test
   (testing "Statistics about statement types should be working."

--- a/src/test/schnaq/database/feedback_form_test.clj
+++ b/src/test/schnaq/database/feedback_form_test.clj
@@ -82,11 +82,11 @@
                                               true)
           updated-feedback (fast-pull feedback-id '[*])]
       (is (not (nil? result)))
-      (is 2 (count (:feedback/items updated-feedback)))
-      (is "blubber" (->> (:feedback/items updated-feedback)
-                         (filter #(= 1 (:feedback.item/ordinal %)))
-                         first
-                         :feedback.item/label))
+      (is (= 2 (count (:feedback/items updated-feedback))))
+      (is (= "blubb" (->> (:feedback/items updated-feedback)
+                          (filter #(= 1 (:feedback.item/ordinal %)))
+                          first
+                          :feedback.item/label)))
       (is (:feedback/visible updated-feedback)))))
 
 (deftest update-feedback-form-items!-without-id-is-double-test
@@ -117,11 +117,11 @@
                                               true)
           updated-feedback (fast-pull feedback-id '[*])]
       (is (not (nil? result)))
-      (is 3 (count (:feedback/items updated-feedback)))
-      (is "blubber" (->> (:feedback/items updated-feedback)
-                         (filter #(= 1 (:feedback.item/ordinal %)))
-                         first
-                         :feedback.item/label))
+      (is (= 3 (count (:feedback/items updated-feedback))))
+      (is (= "blubb" (->> (:feedback/items updated-feedback)
+                          (filter #(= 1 (:feedback.item/ordinal %)))
+                          first
+                          :feedback.item/label)))
       (is (:feedback/visible updated-feedback)))))
 
 (deftest delete-feedback!-test
@@ -157,11 +157,11 @@
                                          true)
           retrieved-items (feedback-items share-hash)]
       (is (seq retrieved-items))
-      (is 2 (count retrieved-items))
-      (is "blubber" (->> retrieved-items
-                         (filter #(= 1 (:feedback.item/ordinal %)))
-                         first
-                         :feedback.item/label)))))
+      (is (= 2 (count retrieved-items)))
+      (is (= "blubb" (->> retrieved-items
+                          (filter #(= 1 (:feedback.item/ordinal %)))
+                          first
+                          :feedback.item/label))))))
 
 (deftest add-answers-test
   (testing "Add answers to questions works as expected."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `Lint code` CI job fails with exit code 2 because clj-kondo reports **11 warnings** (0 errors). This PR clears those warnings and fixes a real bug they were hiding.

## Changes

### Production
- [`common.cljs`](src/main/schnaq/interface/components/common.cljs): remove redundant `(when indicator …)` — `cond` always returns a badge via `:else`
- [`card_elements.cljs`](src/main/schnaq/interface/views/discussion/card_elements.cljs): remove redundant `(when navigation-target …)` — target is always a vector
- [`qa_box.cljs`](src/main/schnaq/interface/views/schnaq/qa_box.cljs): use `let` instead of `when-let` — `normalize` always returns a map
- [`visited.cljs`](src/main/schnaq/interface/views/schnaq/visited.cljs): check raw filter string before `keyword` (clj-kondo treats `keyword` as always truthy); use `(seq …)` instead of `(when-not (empty? …))`
- [`feedback_form.clj`](src/main/schnaq/database/feedback_form.clj): **bugfix** — `update-feedback-form-items!` used `feedback-items`, which only returns items when the form is already visible, so invisible forms never had old items retracted

### Tests
- [`analytics_test.clj`](src/test/schnaq/database/analytics_test.clj): `(is float? …)` → `(is (float? …))`
- [`feedback_form_test.clj`](src/test/schnaq/database/feedback_form_test.clj): fix broken assertions `(is 2 …)` / `(is "blubber" …)` → proper `(is (= …))` with expected labels matching the update data (`"blubb"`)

## Verification

- `clj-kondo --lint src/` → `errors: 0, warnings: 0`
- `clojure -M:test --focus schnaq.database.feedback-form-test --focus schnaq.database.analytics-test` → `20 tests, 55 assertions, 0 failures`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76b5e783-0ff6-4bc0-ad0b-4fcdd16ef780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76b5e783-0ff6-4bc0-ad0b-4fcdd16ef780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

