### PR TITLE
Fix Lexical typing: seed empty paragraph on editor init

### DIFF
--- a/src/main/schnaq/interface/components/lexical/config.cljs
+++ b/src/main/schnaq/interface/components/lexical/config.cljs
@@ -6,6 +6,7 @@
             ["@lexical/react/LexicalHorizontalRuleNode" :refer [HorizontalRuleNode]]
             ["@lexical/rich-text" :refer [HeadingNode QuoteNode]]
             ["@lexical/table" :refer [TableCellNode TableNode TableRowNode]]
+            ["lexical" :refer [$createParagraphNode $getRoot]]
             [re-frame.core :as rf]
             [schnaq.interface.components.lexical.nodes.excalidraw :refer [ExcalidrawNode]]
             [schnaq.interface.components.lexical.nodes.image :refer [ImageNode]]
@@ -81,13 +82,15 @@
 
 (defn- initialize-editor-state
   "Initial editor state. Called only once when the editor is loaded.
-  Convert initial-content from markdown to lexical nodes when provided."
+  Convert initial-content from markdown to lexical nodes, or seed an empty
+  paragraph so the selection has a valid insert target (Lexical 0.48+)."
   [id initial-content]
   (fn [editor]
     (rf/dispatch [:editor/register id editor])
     (rf/dispatch [:editor/content id initial-content])
-    (when initial-content
-      ($convertFromMarkdownString initial-content schnaq-transformers))))
+    (if (seq initial-content)
+      ($convertFromMarkdownString initial-content schnaq-transformers)
+      (.append ($getRoot) ($createParagraphNode)))))
 
 (defn initial-config
   "Initial configuration for all editor instances."


### PR DESCRIPTION
## Summary
- After Lexical 0.4→0.48, empty editors no longer got a root paragraph when `initial-content` was missing
- Typing crashed in `insertText` → `getNodes` (logged via `onError` in `lexical.config`)
- Seed `$createParagraphNode` under `$getRoot` when there is no initial markdown

## Test plan
- [x] agent-browser: `/playground/editor` empty editor accepts typed text (`Hello typing test from agent`)
- [x] agent-browser: naked editor (no toolbar) also accepts typed text
- [x] No console errors during typing
- [ ] Staging: open discussion, type a new statement, submit


Made with [Cursor](https://cursor.com)